### PR TITLE
Update of the link to the xeogl

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,7 +20,7 @@
 
 # Introduction
 
-BIMSurfer is a WebGL-based 3D viewer for [BIMServer]() that's built on [xeoEngine](http://xeoengine.org).
+BIMSurfer is a WebGL-based 3D viewer for [BIMServer]() that's built on [xeogl](https://github.com/xeolabs/xeogl).
  
 TODO: More info
      


### PR DESCRIPTION
The link to "xeoEngine" leads to a wrong page and I propose to be changed to the https://github.com/xeolabs/xeogl.
I also corrected "xeoEngine" to "xeogl".